### PR TITLE
force latest IE rendering engine in intranet

### DIFF
--- a/www/style/1/www/tplMain.php
+++ b/www/style/1/www/tplMain.php
@@ -119,6 +119,7 @@ class tplMain extends Lampcms\Template\Fast
 <meta name="web_root" content="{_WEB_ROOT_}">
 <meta name="form_action" content="{_FORM_ACTION_}">
 <meta name="qid_prefix" content="{_QID_PREFIX_}">
+<meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1"/>
 %8$s
 %9$s
 <link href="%10$s" rel="stylesheet" type="text/css">


### PR DESCRIPTION
LampCMS does not render correctly using IE8 in the intranet - this fixes that issue.
